### PR TITLE
Fix react root versioning issue

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,13 @@
 // src/main.tsx
 import React from 'react'
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom/client'
 import App from './App'
-import { BorderDebuggerProvider } from './context/BorderDebuggerContext'
 
-ReactDOM.render(
+const rootElement = document.getElementById('root') as HTMLElement
+
+const root = ReactDOM.createRoot(rootElement)
+root.render(
   <React.StrictMode>
-    <BorderDebuggerProvider>
-      <App />
-    </BorderDebuggerProvider>
+    <App />
   </React.StrictMode>,
-  document.getElementById('root'),
 )


### PR DESCRIPTION
console err msg: 

```
main.tsx:7 Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```